### PR TITLE
Accept image args provided in input json

### DIFF
--- a/confine.py
+++ b/confine.py
@@ -262,7 +262,7 @@ if __name__ == '__main__':
                 retryCount = 0
                 while ( retryCount < 2 ):
                     start = time.time()
-                    newProfile = containerProfiler.ContainerProfiler(imageName, imageNameFullPath, imageOptions, options.libccfginput, options.muslcfginput, glibcFuncList, muslFuncList, options.strictmode, options.gofolderpath, options.cfgfolderpath, options.finegrain, options.allbinaries, rootLogger)
+                    newProfile = containerProfiler.ContainerProfiler(imageName, imageNameFullPath, imageOptions, options.libccfginput, options.muslcfginput, glibcFuncList, muslFuncList, options.strictmode, options.gofolderpath, options.cfgfolderpath, options.finegrain, options.allbinaries, rootLogger, imageArgs)
                     returncode = newProfile.createSeccompProfile(options.outputfolder + "/" + imageName + "/", options.reportfolder)
                     end = time.time()
                     #if ( returncode != C.SYSDIGERR ):

--- a/container.py
+++ b/container.py
@@ -28,7 +28,7 @@ class Container():
     """
     This class can be used to extract information regarding a container created from a docker image
     """
-    def __init__(self, name, options, logger, remote=None, args=None):
+    def __init__(self, name, options, logger, args, remote=None):
         self.logger = logger
         self.imageName = name
         self.containerName = name

--- a/containerProfiler.py
+++ b/containerProfiler.py
@@ -21,9 +21,10 @@ class ContainerProfiler():
     """
     This class can be used to create a seccomp profile for a container through static anlyasis of the useful binaries
     """
-    def __init__(self, name, imagePath, options, glibccfgpath, muslcfgpath, glibcfunclist, muslfunclist, strictmode, gofolderpath, cfgfolderpath, fineGrain, extractAllBinaries, logger, isDependent=False):
+    def __init__(self, name, imagePath, options, glibccfgpath, muslcfgpath, glibcfunclist, muslfunclist, strictmode, gofolderpath, cfgfolderpath, fineGrain, extractAllBinaries, logger, args, isDependent=False):
         self.logger = logger
         self.name = name
+        self.args = args
         self.imagePath = imagePath
         #self.name = name
         #if ( "/" in self.name ):
@@ -295,7 +296,7 @@ class ContainerProfiler():
         self.logger.debug("binaryReady: %s libFileReady: %s", str(binaryReady), str(libFileReady))
 
 
-        myContainer = container.Container(self.imagePath, self.options, self.logger)
+        myContainer = container.Container(self.imagePath, self.options, self.logger, self.args)
         self.containerName = myContainer.getContainerName()
 
         if ( not myContainer.pruneVolumes() ):


### PR DESCRIPTION
Hello @shamedgh,

**Problem statement**
- Sometimes it's required to harden Docker images with command args.
- Consider the following example, where input image json contains args
```
$ cat image.json 
{
    "nginx": {
        "enable": "true",
        "image-name": "nginx",
        "image-url": "nginx",
        "options": "",
        "args": "nginx-debug -g 'daemon off;'"
    }
}
```
- During initial `runWithoutSeccomp`
  - https://github.com/shamedgh/confine/blob/master/container.py#L111
  - the cmd does not take the input args from `image.json`
  - (For verification added print `cmd` value)
- Launch confine to harden container image with respective args
```
$ sudo python3.8 confine.py -d -l libc-callgraphs/glibc.2.31.callgraph -m libc-callgraphs/musllibc.callgraph -i image.json -o output/ -p default.seccomp.json -r results/ -g go.syscalls/ --finegrain --othercfgfolder other-callgraphs 2>&1 | tee confinerun_master.log 

...<SKIP>...
DEBUG runWithoutSeccomp() cmd=sudo docker  run -l CONFINE --security-opt seccomp=unconfined --name nginx-container-CONFINE  -td nginx 
...<SKIP>...
```
- Log: 
[confinerun_master.log](https://github.com/shamedgh/confine/files/7408287/confinerun_master.log)


**Changes**
- Sometimes need to input args for container.
- This PR updates required changes to run confine with input args to container.
- Example confine run with changes (`input.json` same as above)
```
$ sudo python3.8 confine.py -d -l libc-callgraphs/glibc.2.31.callgraph -m libc-callgraphs/musllibc.callgraph -i image.json -o output/ -p default.seccomp.json -r results/ -g go.syscalls/ --finegrain --othercfgfolder other-callgraphs 2>&1 | tee confinerun-accept-command-args.log 
...<SKIP>...
DEBUG runWithoutSeccomp() cmd=sudo docker  run -l CONFINE --security-opt seccomp=unconfined --name nginx-container-CONFINE  -td nginx nginx-debug -g 'daemon off;'
...<SKIP>...
```
- With PR changes confine can launch container with input args and required binaries are copied to `output/` dir
- Log: 
[confinerun-accept-command-args.log](https://github.com/shamedgh/confine/files/7408289/confinerun-accept-command-args.log)

