### PR TITLE
Handle image name with special char

### DIFF
--- a/confine.py
+++ b/confine.py
@@ -5,6 +5,7 @@ import containerProfiler
 import container
 import time
 import json
+import re
 
 sys.path.insert(0, './python-utils/')
 
@@ -212,6 +213,8 @@ if __name__ == '__main__':
             retryCount = 0
             depLinkSet = set()
             imageName = imageVals.get("image-name", imageKey)
+            tmpimageName = imageVals.get("image-name", imageKey)
+            imageName = re.sub('\W+','-', tmpimageName)
             if ( imageVals.get("enable", "false") == "true" and imageName not in skipList ):
                 rootLogger.info("------------------------------------------------------------------------")
                 rootLogger.info("////////////////////////////////////////////////////////////////////////")
@@ -224,7 +227,8 @@ if __name__ == '__main__':
 
                 imageDependencies = imageVals.get("dependencies", dict())
                 for depKey, depVals in imageDependencies.items():
-                    depImageName = depVals.get("image-name", depKey)
+                    tmpdepImageName = depVals.get("image-name", depKey)
+                    depImageName = re.sub('\W+','-', tmpdepImageName)
                     depImageNameFullPath = depVals.get("image-url", depImageName)
                     depOptions = depVals.get("options", "")
                     depLink = True if depVals.get("link", False) else False


### PR DESCRIPTION
Hello @shamedgh,

**Problem Statement**
- Sometimes required to harden container images of specific tag.
- When image name is mentioned with tag name in input image json file, the `output//<imagename>` is created. In that case Confine fails to harden container image, since unable to read any binaries or libraries from  `output//<imagename>` .
- Consider the following example
```
$ cat image.json 
{
    "nginx": {
        "enable": "true",
        "image-name": "nginx:1.21.3",
        "image-url": "nginx:1.21.3",
        "options": "",
        "args": ""
    }
}
```
- Run confine to harden `"nginx:1.21.3"` image
```
$ sudo python3.8 confine.py -d -l libc-callgraphs/glibc.2.31.callgraph -m libc-callgraphs/musllibc.callgraph -i image.json -o output/ -p default.seccomp.json -r results/ -g go.syscalls/ --finegrain --othercfgfolder other-callgraphs/ 2>&1 | tee confinerun-master-imagename.log 
...<SKIP>...
Successfully created directory: output//nginx:1.21.3/
...<SKIP>...
Finished sleeping, extracting psNames for nginx:1.21.3
Starting to identify running processes and required binaries and libraries through dynamic analysis.

nginx:1.21.3 container can't be hardened because no functions can be extracted from binaries and no direct syscalls found
Tried hardening container: nginx:1.21.3 returned: -3:No imported functions could be extracted from any of the binaries and libraries required by the container
```
- Log: 
[confinerun-master-imagename.log](https://github.com/shamedgh/confine/files/7409463/confinerun-master-imagename.log)


**Changes**
- Convert any special characters in `image-name` to only alpha-num value
- This updates the imagename 
- Example: `"image-name": "nginx:1.21.3"` -> `output/nginx1213`
- Using above `image.json`
```
$ sudo rm -rf output/ results/
$ sudo python3.8 confine.py -d -l libc-callgraphs/glibc.2.31.callgraph -m libc-callgraphs/musllibc.callgraph -i image.json -o output/ -p default.seccomp.json -r results/ -g go.syscalls/ --finegrain --othercfgfolder other-callgraphs/ 2>&1 | tee confinerun-handle-ouputdir-imagename.log 
...<SKIP>...
Successfully created directory: output//nginx1213/
...<SKIP>...
--->Validating generated Seccomp profile: results//nginx1213.seccomp.json
Running container nginx
docker inspect status returned: true

************************************************************************************
Finished validation. Container for image: nginx1213 was hardened SUCCESSFULLY!
************************************************************************************
```
- Log: 
[confinerun-handle-ouputdir-imagename-1.log](https://github.com/shamedgh/confine/files/7409521/confinerun-handle-ouputdir-imagename-1.log)
