### PR TITLE
Add option to choose syscall number mapping method

### DIFF
--- a/binaryProfiler.py
+++ b/binaryProfiler.py
@@ -65,6 +65,9 @@ if __name__ == '__main__':
     parser.add_option("-d", "--debug", dest="debug", action="store_true", default=False,
                       help="Debug enabled/disabled")
 
+    parser.add_option("-t", "--maptype", dest="maptype", default="awk",
+                      help="Syscall number mapping method: awk, auditd, libseccomp")
+
     (options, args) = parser.parse_args()
     if isValidOpts(options):
         rootLogger = setLogPath("binaryprofiler.log")
@@ -75,7 +78,7 @@ if __name__ == '__main__':
         dockerSyscalls = ["access","arch_prctl","brk","close","execve","exit_group","fcntl","fstat","geteuid","lseek","mmap","mprotect","munmap","openat","prlimit64","read","rt_sigaction","rt_sigprocmask","set_robust_list","set_tid_address","stat","statfs","write","setns","capget","capset","chdir","fchown","futex","getdents64","getpid","getppid","lstat","openat","prctl","setgid","setgroups","setuid","stat","io_setup","getdents","clone","readlinkat","newfstatat","getrandom","sigaltstack","getresgid","getresuid","setresgid","setresuid","alarm","getsid","getpgrp", "epoll_pwait", "vfork"]
 
         syscallObj = syscall.Syscall(rootLogger)
-        syscallMap = syscallObj.createMap()
+        syscallMap = syscallObj.createMap(options.maptype)
         syscallInverseMap = syscallObj.getInverseMap()
         dockerSyscallNums = set()
         for syscallStr in dockerSyscalls:

--- a/confine.py
+++ b/confine.py
@@ -111,6 +111,9 @@ if __name__ == '__main__':
     parser.add_option("-d", "--debug", dest="debug", action="store_true", default=False,
                       help="Debug enabled/disabled")
 
+    parser.add_option("-t", "--maptype", dest="maptype", default="awk",
+                      help="Syscall number mapping method: awk, auditd, libseccomp")
+
     (options, args) = parser.parse_args()
     if isValidOpts(options):
         rootLogger = setLogPath("containerprofiler.log")
@@ -236,7 +239,7 @@ if __name__ == '__main__':
 
                     retryCount = 0
                     while ( retryCount < 2 ):
-                        newProfile = containerProfiler.ContainerProfiler(depImageName, depImageNameFullPath, depOptions, options.libccfginput, options.muslcfginput, glibcFuncList, muslFuncList, options.strictmode, options.gofolderpath, options.cfgfolderpath, options.finegrain, options.allbinaries, rootLogger, True)
+                        newProfile = containerProfiler.ContainerProfiler(depImageName, depImageNameFullPath, depOptions, options.libccfginput, options.muslcfginput, glibcFuncList, muslFuncList, options.strictmode, options.gofolderpath, options.cfgfolderpath, options.finegrain, options.allbinaries, rootLogger, options.maptype, True)
                         returncode = newProfile.createSeccompProfile(options.outputfolder + "/" + depImageName + "/", options.reportfolder)
                         #if ( returncode != C.SYSDIGERR ):
                         if ( returncode == 0 ):
@@ -266,7 +269,7 @@ if __name__ == '__main__':
                 retryCount = 0
                 while ( retryCount < 2 ):
                     start = time.time()
-                    newProfile = containerProfiler.ContainerProfiler(imageName, imageNameFullPath, imageOptions, options.libccfginput, options.muslcfginput, glibcFuncList, muslFuncList, options.strictmode, options.gofolderpath, options.cfgfolderpath, options.finegrain, options.allbinaries, rootLogger, imageArgs)
+                    newProfile = containerProfiler.ContainerProfiler(imageName, imageNameFullPath, imageOptions, options.libccfginput, options.muslcfginput, glibcFuncList, muslFuncList, options.strictmode, options.gofolderpath, options.cfgfolderpath, options.finegrain, options.allbinaries, rootLogger, options.maptype, imageArgs)
                     returncode = newProfile.createSeccompProfile(options.outputfolder + "/" + imageName + "/", options.reportfolder)
                     end = time.time()
                     #if ( returncode != C.SYSDIGERR ):

--- a/containerProfiler.py
+++ b/containerProfiler.py
@@ -21,7 +21,7 @@ class ContainerProfiler():
     """
     This class can be used to create a seccomp profile for a container through static anlyasis of the useful binaries
     """
-    def __init__(self, name, imagePath, options, glibccfgpath, muslcfgpath, glibcfunclist, muslfunclist, strictmode, gofolderpath, cfgfolderpath, fineGrain, extractAllBinaries, logger, args, isDependent=False):
+    def __init__(self, name, imagePath, options, glibccfgpath, muslcfgpath, glibcfunclist, muslfunclist, strictmode, gofolderpath, cfgfolderpath, fineGrain, extractAllBinaries, logger, maptype, args, isDependent=False):
         self.logger = logger
         self.name = name
         self.args = args
@@ -39,6 +39,7 @@ class ContainerProfiler():
         self.strictMode = strictmode
         self.goFolderPath = gofolderpath
         self.cfgFolderPath = cfgfolderpath
+        self.maptype = maptype
         self.status = False
         self.runnable = False
         self.installStatus = False
@@ -567,7 +568,7 @@ class ContainerProfiler():
                 self.logger.debug("After reading file: %s len(staticSyscallList): %d", os.path.join(self.goFolderPath, self.name + ".syscalls"), len(staticSyscallList))
 
                 syscallMapper = syscall.Syscall(self.logger)
-                syscallMap = syscallMapper.createMap()
+                syscallMap = syscallMapper.createMap(self.maptype)
 
                 self.logger.info("Generating final system call filter list")
                 blackListOriginal = []
@@ -762,7 +763,8 @@ class ContainerProfiler():
             allSyscalls.add(syscallNum)
 
         syscallMapper = syscall.Syscall(self.logger)
-        syscallMap = syscallMapper.createMap()
+        syscallMap = syscallMapper.createMap(self.maptype)
+
         blackList = set()
         i = 0
         while i < 400:

--- a/extractSysCalls.py
+++ b/extractSysCalls.py
@@ -134,7 +134,7 @@ if __name__ == '__main__':
         print (str(len(syscallList)))
         print (syscallList)
         syscallMapper = syscall.Syscall(rootLogger)
-        syscallMap = syscallObj.createMap(options.maptype)
+        syscallMap = syscallMapper.createMap(options.maptype)
 
         blackList = []
         i = 1

--- a/extractSysCalls.py
+++ b/extractSysCalls.py
@@ -68,6 +68,9 @@ if __name__ == '__main__':
     parser.add_option("-d", "--debug", dest="debug", action="store_true", default=False,
                       help="Debug enabled/disabled")
 
+    parser.add_option("-t", "--maptype", dest="maptype", default="awk",
+                      help="Syscall number mapping method: awk, auditd, libseccomp")
+
     (options, args) = parser.parse_args()
     if isValidOpts(options):
         rootLogger = setLogPath("syscallextractor.log")
@@ -131,7 +134,7 @@ if __name__ == '__main__':
         print (str(len(syscallList)))
         print (syscallList)
         syscallMapper = syscall.Syscall(rootLogger)
-        syscallMap = syscallMapper.createMap()
+        syscallMap = syscallObj.createMap(options.maptype)
 
         blackList = []
         i = 1

--- a/finegrainProfileTest.py
+++ b/finegrainProfileTest.py
@@ -93,6 +93,9 @@ if __name__ == '__main__':
     parser.add_option("-d", "--debug", dest="debug", action="store_true", default=False,
                       help="Debug enabled/disabled")
 
+    parser.add_option("-t", "--maptype", dest="maptype", default="awk",
+                      help="Syscall number mapping method: awk, auditd, libseccomp")
+
     (options, args) = parser.parse_args()
     if isValidOpts(options):
         rootLogger = setLogPath("finegrainedcontainerprofiler.log")
@@ -142,7 +145,7 @@ if __name__ == '__main__':
 
             if ( not imageRank.startswith("#") and imageName not in skipList ):
                 start = time.time()
-                newProfile = containerProfiler.ContainerProfiler(imageName, imageNameFullPath, imageOptions, options.libccfginput, options.muslcfginput, glibcFuncList, muslFuncList, options.strictmode, options.gofolderpath, options.cfgfolderpath, rootLogger)
+                newProfile = containerProfiler.ContainerProfiler(imageName, imageNameFullPath, imageOptions, options.libccfginput, options.muslcfginput, glibcFuncList, muslFuncList, options.strictmode, options.gofolderpath, options.cfgfolderpath, options.maptype, rootLogger)
 #                returncode = newProfile.createSeccompProfile(options.outputfolder + "/" + imageName + "/", options.reportfolder)
                 returncode = newProfile.createFineGrainedSeccompProfile(options.outputfolder + "/" + imageName + "/", options.reportfolder)
                 end = time.time()

--- a/python-utils/syscall.py
+++ b/python-utils/syscall.py
@@ -7,10 +7,25 @@ class Syscall():
     """
     def __init__(self, logger):
         self.logger = logger
+        self.syscallMapType = ""
         self.syscallMap = dict()        #Num->Name
         self.syscallInverseMap = dict()     #Name->Num
 
-    def createMap(self):
+    def createMap(self, mapType):
+        self.syscallMapType = mapType
+        if self.syscallMapType == "awk":
+            mapDict = self.createMapWithAwk()
+        elif self.syscallMapType == "auditd":
+            mapDict = self.createMapWithAuditd()
+        elif self.syscallMapType == "libseccomp":
+            mapDict = self.createMapWithLibseccompTool()
+        else:
+            self.logger.info("Invalid syscall number mapping type specified, using awk")
+            mapDict = self.createMapWithAwk()
+
+        return mapDict
+
+    def createMapWithAwk(self):
         mapCmd = 'awk \'BEGIN { print "#include <sys/syscall.h>" } /p_syscall_meta/ { syscall = substr($NF, 19); printf "syscalls[SYS_%s] = \\"%s\\";\\n", syscall, syscall }\' /proc/kallsyms | sort -u | gcc -E -P -'
         proc = subprocess.Popen([mapCmd], shell=True, stdout=subprocess.PIPE)
         (out, err) = proc.communicate()
@@ -31,9 +46,6 @@ class Syscall():
                 continue
         return self.syscallMap
 
-    def getInverseMap(self):
-        return self.syscallInverseMap
-
     def createMapWithAuditd(self):
         mapCmd = "ausyscall --dump"
         returncode, out, err = util.runCommand(mapCmd)
@@ -53,6 +65,38 @@ class Syscall():
                 self.logger.debug("Syscall Number isn't integer: %s", syscallNum)
                 continue
         return self.syscallMap
+
+    def createMapWithLibseccompTool(self):
+        mapCmd = 'syscall-num-name'
+        if util.shutil.which(mapCmd) == None:
+            self.logger.error(mapCmd + " not found. Please install " + mapCmd + " tool")
+            self.logger.error("Refer https://github.com/chethanah/syscall-num-name for installation steps")
+            sys.exit("Error creating syscall map using libseccomp tool, exiting program")
+
+        proc = subprocess.Popen([mapCmd], shell=True, stdout=subprocess.PIPE)
+        (out, err) = proc.communicate()
+        splittedOut = out.splitlines()
+        self.logger.debug("Libsecccomp-rs based syscall map count found: %d", \
+                            len(splittedOut))
+        for outLineObj in splittedOut:
+            outLine = str(outLineObj.decode("utf-8"))
+            leftHand = outLine.split(" = ")[0]
+            syscallNum = leftHand[9:-1]
+            rightHand = outLine.split(" = ")[1]
+            syscallName = rightHand[1:-2]
+            try:
+                self.syscallMap[int(syscallNum)] = syscallName.strip()
+                self.syscallInverseMap[syscallName.strip()] = int(syscallNum)
+            except:
+                self.logger.debug("Syscall Number isn't integer: %s", syscallNum)
+                continue
+        return self.syscallMap
+
+    def getInverseMap(self):
+        return self.syscallInverseMap
+
+    def getSyscallMapType(self):
+        return self.syscallMapType
 
     def findDiff(self, dict1, dict2):
         for key, value in dict1.items():


### PR DESCRIPTION
1. Currently, the syscall number mapping techinque is based
on AWK command. This change allows to select various
mapping techniques such as AWK, auditd etc.

2. Added support for custom syscall number mapping method based
on libseccomp-rs. Please refer
https://github.com/chethanah/syscall-num-name