### PR TITLE
Fix attribute error due to redundant string conversion

### DIFF
--- a/python-utils/syscall.py
+++ b/python-utils/syscall.py
@@ -52,10 +52,9 @@ class Syscall():
         if ( returncode != 0 ):
             self.logger.error("Error creating syscall map using ausyscall: %s", err)
             return None
-        splittedOut = out.splitlines()
-        self.logger.debug("Auditd Syscall map count found: %d", len(splittedOut))
-        for outLineObj in splittedOut[1:]:
-            outLine = str(outLineObj.decode("utf-8"))
+        splittedOutStr = out.splitlines()
+        self.logger.debug("Auditd Syscall map count found: %d", len(splittedOutStr))
+        for outLine in splittedOutStr[1:]:
             syscallNum = outLine.split()[0]
             syscallName = outLine.split()[1]
             try:


### PR DESCRIPTION
The runCommand function in utils.py script already
converts both stdout and stderr outputs of a command to string format.
The converted output strings are again converted in createMapWithAuditd
function. This results to attribute error. So remove the additional
string conversion in createMapWithAuditd function.